### PR TITLE
Log unknown errors

### DIFF
--- a/models/queued_jobs/queued_jobs.go
+++ b/models/queued_jobs/queued_jobs.go
@@ -175,7 +175,7 @@ func Enqueue(id types.PrefixUUID, name string, runAfter time.Time, expiresAt typ
 }
 
 // Get the queued job with the given id. Returns the job, or an error. If no
-// record could be found, the error will be `sql.ErrNoRows`.
+// record could be found, the error will be `queued_jobs.ErrNotFound`.
 func Get(id types.PrefixUUID) (*models.QueuedJob, error) {
 	if id.UUID == nil {
 		return nil, errors.New("Invalid id")

--- a/services/process_job.go
+++ b/services/process_job.go
@@ -130,6 +130,7 @@ func (jp *JobProcessor) requestRetry(qj *models.QueuedJob) error {
 					if isTimeout(err) {
 						metrics.Increment("dequeue.post_job.timeout")
 					} else {
+						log.Printf("Unknown error making POST request to downstream server: %#v", err)
 						metrics.Increment("dequeue.post_job.error_unknown")
 					}
 				}(err)


### PR DESCRIPTION
In this case I was hitting this error because I was returning the empty string
for a HTTP response, instead of returning a decodable JSON object and it was
difficult to track down why this was happening. Let's log an error message if
we hit an unknown error so we can see why we are hitting this error case.

Also fixes the docstring for queued_jobs.Get.