### PR TITLE
Add a benchmark for enqueueing data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: go
+go_import_path: github.com/Shyp/rickover
 
 go:
   - 1.5
   - 1.6
+  - 1.7
   - tip
 
-script: make lint race-test
+script: make lint race-test bench
 
 before_script:
   - make test-install
@@ -13,7 +15,9 @@ before_script:
   - goose --env=travis up
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
 
 services:
   - postgresql
+
+dist: trusty

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/Shyp/rickover",
 	"GoVersion": "go1.5",
-	"GodepVersion": "v72",
+	"GodepVersion": "v75",
 	"Packages": [
 		"./..."
 	],

--- a/test/factory/factory.go
+++ b/test/factory/factory.go
@@ -63,7 +63,7 @@ func RandomId(prefix string) types.PrefixUUID {
 	}
 }
 
-func CreateJob(t *testing.T, j models.Job) models.Job {
+func CreateJob(t testing.TB, j models.Job) models.Job {
 	test.SetUp(t)
 	job, err := jobs.Create(j)
 	test.AssertNotError(t, err, "")
@@ -72,12 +72,12 @@ func CreateJob(t *testing.T, j models.Job) models.Job {
 
 // CreateQueuedJob creates a job and a queued job with the given JSON data, and
 // returns the created queued job.
-func CreateQueuedJob(t *testing.T, data json.RawMessage) *models.QueuedJob {
+func CreateQueuedJob(t testing.TB, data json.RawMessage) *models.QueuedJob {
 	return createJobAndQueuedJob(t, SampleJob, data, false)
 }
 
 // CreateQJ creates a job with a random name, and a random UUID.
-func CreateQJ(t *testing.T) *models.QueuedJob {
+func CreateQJ(t testing.TB) *models.QueuedJob {
 	test.SetUp(t)
 	jobname := RandomId("jobtype")
 	job, err := jobs.Create(models.Job{
@@ -118,7 +118,7 @@ func CreateAtMostOnceJob(t *testing.T, data json.RawMessage) *models.QueuedJob {
 	return createJobAndQueuedJob(t, SampleAtMostOnceJob, data, false)
 }
 
-func createJobAndQueuedJob(t *testing.T, j models.Job, data json.RawMessage, randomId bool) *models.QueuedJob {
+func createJobAndQueuedJob(t testing.TB, j models.Job, data json.RawMessage, randomId bool) *models.QueuedJob {
 	test.SetUp(t)
 	_, err := jobs.Create(j)
 	if err != nil {

--- a/test/server/bench_test.go
+++ b/test/server/bench_test.go
@@ -1,0 +1,40 @@
+package servertest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	types "github.com/Shyp/rickover/Godeps/_workspace/src/github.com/Shyp/go-types"
+	"github.com/Shyp/rickover/server"
+	"github.com/Shyp/rickover/test"
+	"github.com/Shyp/rickover/test/factory"
+)
+
+func BenchmarkEnqueue(b *testing.B) {
+	defer test.TearDown(b)
+	expiry := time.Now().UTC().Add(5 * time.Minute)
+	ejr := &server.EnqueueJobRequest{
+		Data:      factory.EmptyData,
+		ExpiresAt: types.NullTime{Valid: true, Time: expiry},
+	}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(ejr)
+	bits := buf.Bytes()
+	_ = factory.CreateJob(b, factory.SampleJob)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		req, _ := http.NewRequest("PUT", "/v1/jobs/echo/random_id", bytes.NewReader(bits))
+		req.SetBasicAuth("test", testPassword)
+		w := httptest.NewRecorder()
+		server.DefaultServer.ServeHTTP(w, req)
+		b.SetBytes(int64(w.Body.Len()))
+		if w.Code != 202 {
+			b.Fatalf("incorrect Code: %d (response %s)", w.Code, w.Body.Bytes())
+		}
+	}
+}

--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -23,6 +23,10 @@ var u = &server.UnsafeBypassAuthorizer{}
 
 var testPassword = "XmTGoDTRyVd8HHiuzFtPzF8N&or7ETPaPVvWuR;d"
 
+func init() {
+	server.DefaultAuthorizer.AddUser("test", testPassword)
+}
+
 func TestGoodRequestReturns200(t *testing.T) {
 	defer test.TearDown(t)
 	factory.CreateQueuedJob(t, factory.EmptyData)
@@ -137,7 +141,6 @@ func TestRetrieveJobNoName(t *testing.T) {
 	defer test.TearDown(t)
 	factory.CreateQueuedJob(t, factory.EmptyData)
 	w := httptest.NewRecorder()
-	server.DefaultAuthorizer.AddUser("test", testPassword)
 	req, _ := http.NewRequest("GET", "/v1/jobs/job_6740b44e-13b9-475d-af06-979627e0e0d6", nil)
 	req.SetBasicAuth("test", testPassword)
 	server.DefaultServer.ServeHTTP(w, req)

--- a/test/test-tools.go
+++ b/test/test-tools.go
@@ -32,42 +32,42 @@ func caller() string {
 }
 
 // Assert a boolean
-func Assert(t *testing.T, result bool, message string) {
+func Assert(t testing.TB, result bool, message string) {
 	if !result {
 		t.Fatalf("%s %s", caller(), message)
 	}
 }
 
 // AssertNotNil checks an object to be non-nil
-func AssertNotNil(t *testing.T, obj interface{}, message string) {
+func AssertNotNil(t testing.TB, obj interface{}, message string) {
 	if obj == nil {
 		t.Fatalf("%s %s", caller(), message)
 	}
 }
 
 // AssertNotError checks that err is nil
-func AssertNotError(t *testing.T, err error, message string) {
+func AssertNotError(t testing.TB, err error, message string) {
 	if err != nil {
 		t.Fatalf("%s %s: %s", caller(), message, err)
 	}
 }
 
 // AssertError checks that err is non-nil
-func AssertError(t *testing.T, err error, message string) {
+func AssertError(t testing.TB, err error, message string) {
 	if err == nil {
 		t.Fatalf("%s %s: expected error but received none", caller(), message)
 	}
 }
 
 // AssertEquals uses the equality operator (==) to measure one and two
-func AssertEquals(t *testing.T, one interface{}, two interface{}) {
+func AssertEquals(t testing.TB, one interface{}, two interface{}) {
 	if one != two {
 		t.Fatalf("%s [%v] != [%v]", caller(), one, two)
 	}
 }
 
 // AssertDeepEquals uses the reflect.DeepEqual method to measure one and two
-func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
+func AssertDeepEquals(t testing.TB, one interface{}, two interface{}) {
 	if !reflect.DeepEqual(one, two) {
 		t.Fatalf("%s [%+v] !(deep)= [%+v]", caller(), one, two)
 	}
@@ -75,7 +75,7 @@ func AssertDeepEquals(t *testing.T, one interface{}, two interface{}) {
 
 // AssertMarshaledEquals marshals one and two to JSON, and then uses
 // the equality operator to measure them
-func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
+func AssertMarshaledEquals(t testing.TB, one interface{}, two interface{}) {
 	oneJSON, err := json.Marshal(one)
 	AssertNotError(t, err, "Could not marshal 1st argument")
 	twoJSON, err := json.Marshal(two)
@@ -88,14 +88,14 @@ func AssertMarshaledEquals(t *testing.T, one interface{}, two interface{}) {
 
 // AssertNotEquals uses the equality operator to measure that one and two
 // are different
-func AssertNotEquals(t *testing.T, one interface{}, two interface{}) {
+func AssertNotEquals(t testing.TB, one interface{}, two interface{}) {
 	if one == two {
 		t.Fatalf("%s [%v] == [%v]", caller(), one, two)
 	}
 }
 
 // AssertByteEquals uses bytes.Equal to measure one and two for equality.
-func AssertByteEquals(t *testing.T, one []byte, two []byte) {
+func AssertByteEquals(t testing.TB, one []byte, two []byte) {
 	if !bytes.Equal(one, two) {
 		t.Fatalf("%s Byte [%s] != [%s]",
 			caller(),
@@ -105,7 +105,7 @@ func AssertByteEquals(t *testing.T, one []byte, two []byte) {
 }
 
 // AssertIntEquals uses the equality operator to measure one and two.
-func AssertIntEquals(t *testing.T, one int, two int) {
+func AssertIntEquals(t testing.TB, one int, two int) {
 	if one != two {
 		t.Fatalf("%s Int [%d] != [%d]", caller(), one, two)
 	}
@@ -113,34 +113,34 @@ func AssertIntEquals(t *testing.T, one int, two int) {
 
 // AssertBigIntEquals uses the big.Int.cmp() method to measure whether
 // one and two are equal
-func AssertBigIntEquals(t *testing.T, one *big.Int, two *big.Int) {
+func AssertBigIntEquals(t testing.TB, one *big.Int, two *big.Int) {
 	if one.Cmp(two) != 0 {
 		t.Fatalf("%s Int [%d] != [%d]", caller(), one, two)
 	}
 }
 
 // AssertContains determines whether needle can be found in haystack
-func AssertContains(t *testing.T, haystack string, needle string) {
+func AssertContains(t testing.TB, haystack string, needle string) {
 	if !strings.Contains(haystack, needle) {
 		t.Fatalf("%s String [%s] does not contain [%s]", caller(), haystack, needle)
 	}
 }
 
 // AssertNotContains determines if needle is not found in haystack
-func AssertNotContains(t *testing.T, haystack string, needle string) {
+func AssertNotContains(t testing.TB, haystack string, needle string) {
 	if strings.Contains(haystack, needle) {
 		t.Fatalf("%s String [%s] contains [%s]", caller(), haystack, needle)
 	}
 }
 
 // AssertSeverity determines if a string matches the Severity formatting
-func AssertSeverity(t *testing.T, data string, severity int) {
+func AssertSeverity(t testing.TB, data string, severity int) {
 	expected := fmt.Sprintf("\"severity\":%d", severity)
 	AssertContains(t, data, expected)
 }
 
 // AssertBetween determines if a is between b and c
-func AssertBetween(t *testing.T, a, b, c int64) {
+func AssertBetween(t testing.TB, a, b, c int64) {
 	if a < b || a > c {
 		t.Fatalf("%d is not between %d and %d", a, b, c)
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Shyp/rickover/setup"
 )
 
-func SetUp(t *testing.T) {
+func SetUp(t testing.TB) {
 	if os.Getenv("DATABASE_URL") == "" {
 		os.Setenv("DATABASE_URL", "postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC")
 	}
@@ -33,7 +33,7 @@ func TruncateTables() error {
 
 // TearDown deletes all records from the database, and marks the test as failed
 // if this was unsuccessful.
-func TearDown(t *testing.T) {
+func TearDown(t testing.TB) {
 	if db.Connected() {
 		if err := TruncateTables(); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This lets us measure how fast jobs can be enqueued (about 0.8ms per run).
Updates a bunch of *testing.T to instead take the testing.TB interface, so
we can pass a *testing.B and have things still work. Adds a Make target for
running benchmarks. Run the benchmarks in Travis CI, and specify the
go_import_path so forks still build okay.