### PR TITLE
Add GetOrDefault to config package and use it to potentially get server creds.

### DIFF
--- a/commands/server/main.go
+++ b/commands/server/main.go
@@ -36,9 +36,15 @@ func configure() (http.Handler, error) {
 
 	go setup.MeasureActiveQueries(5 * time.Second)
 
-	// If you run this in production, change this user.
-	server.AddUser("test", "hymanrickover")
+	configureUser()
 	return server.Get(server.DefaultAuthorizer), nil
+}
+
+func configureUser() {
+	// These should be set if you're running this in production
+	userName := config.GetOrDefault("RICKOVER_USER_NAME", "test")
+	password := config.GetOrDefault("RICKOVER_PASSWORD", "hymanrickover")
+	server.AddUser(userName, password)
 }
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,14 @@ func GetURLOrBail(urlEnvVar string) *url.URL {
 	return parsedUrl
 }
 
+func GetOrDefault(envVar string, defaultValue string) string {
+	envValue := os.Getenv(envVar)
+	if envValue == "" {
+		return defaultValue
+	}
+	return envValue
+}
+
 // SetMaxIdleConnsPerHost sets the MaxIdleConnsPerHost value for the default
 // HTTP transport. If you are using a custom transport, calling this function
 // won't change anything.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,3 +35,18 @@ func TestGetIntError(t *testing.T) {
 	_, err = GetInt("CONFIG_TEST_INT_VAR")
 	test.AssertError(t, err, "getting bad env var")
 }
+
+func TestGetOrDefaultNonDefault(t *testing.T) {
+	err := os.Setenv("CONFIG_TEST_STRING_VAR", "HEY")
+	test.AssertNotError(t, err, "setting env var")
+	defer func() {
+		os.Unsetenv("CONFIG_TEST_STRING_VAR")
+	}()
+	s := GetOrDefault("CONFIG_TEST_STRING_VAR", "TEST")
+	test.AssertEquals(t, s, "HEY")
+}
+
+func TestGetOrDefaultDefault(t *testing.T) {
+	s := GetOrDefault("CONFIG_TEST_STRING_VAR", "TEST")
+	test.AssertEquals(t, s, "TEST")
+}


### PR DESCRIPTION
In response to #11, pull the server credentials from the environment so that the code in the commands directory can potentially be used directly in production.