### PR TITLE
Declare dependencies in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ go:
 script: make lint race-test bench
 
 before_script:
+  - cat Makefile
+  - pwd
+  - env
+  - make -v
   - make test-install
   - go get -u github.com/kevinburke/goose/cmd/goose
   - goose --env=travis up

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ before_script:
   - go get -u github.com/kevinburke/goose/cmd/goose
   - goose --env=travis up
 
+env:
+  - GOPATH=/home/travis/gopath
+
 addons:
   postgresql: "9.5"
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 .PHONY: install test race-test
 
-SHELL = /bin/bash
+SHELL = /bin/bash -x -o pipefail
 
 ifdef DATABASE_URL
-DATABASE_URL = $(DATABASE_URL)
-TEST_DATABASE_URL = $(DATABASE_URL)
+DATABASE_URL := $(DATABASE_URL)
+TEST_DATABASE_URL := $(DATABASE_URL)
 else
-DATABASE_URL = 'postgres://rickover@localhost:5432/rickover?sslmode=disable&timezone=UTC'
-TEST_DATABASE_URL = 'postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC'
+DATABASE_URL := 'postgres://rickover@localhost:5432/rickover?sslmode=disable&timezone=UTC'
+TEST_DATABASE_URL := 'postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC'
 endif
 
-BENCHSTAT := $(shell command -v benchstat)
+BENCHSTAT := "$(GOPATH)/bin/benchstat"
+BUMP_VERSION := "$(GOPATH)/bin/bump_version"
+GODOCDOC := "$(GOPATH)/bin/godocdoc"
+GOOSE := "$(GOPATH)/bin/goose"
 
-test-install: 
+test-install:
 	-createuser rickover --superuser --createrole --createdb --inherit
 	-createdb rickover --owner=rickover
 	-createdb rickover_test --owner=rickover
@@ -26,12 +29,14 @@ build:
 install:
 	go install ./...
 
-docs:
-	go get golang.org/x/tools/cmd/godoc
-	(sleep 1; open http://localhost:6060/pkg/github.com/Shyp/rickover) &
-	godoc -http=:6060
+$(GODOCDOC):
+	echo "$(GOPATH)"
+	go get -u github.com/kevinburke/godocdoc
 
-testonly: 
+docs: | $(GODOCDOC)
+	"$(GODOCDOC)"
+
+testonly:
 	@DATABASE_URL=$(TEST_DATABASE_URL) go test -p 1 ./... -timeout 2s
 
 race-testonly:
@@ -50,18 +55,23 @@ serve:
 dequeue:
 	@DATABASE_URL=$(DATABASE_URL) go run commands/dequeuer/main.go
 
-release: race-test
-	go get github.com/Shyp/bump_version
-	bump_version minor config/config.go
+$(BUMP_VERSION):
+	go get -u github.com/Shyp/bump_version
+
+release: race-test | $(BUMP_VERSION)
+	$(BUMP_VERSION) minor config/config.go
 	git push origin master
 	git push origin master --tags
 
-migrate:
-	goose --env=development up
-	goose --env=test up
+GOOSE:
+	go get -u github.com/kevinburke/goose/cmd/goose
 
-bench:
-ifndef BENCHSTAT
-	go get -u rsc.io/benchstat
-endif
-	tmp=$$(mktemp); go list ./... | grep -v vendor | xargs go test -benchtime=2s -bench=. -run='^$$' > "$$tmp" 2>&1 && benchstat "$$tmp"
+migrate: | $(GOOSE)
+	$(GOOSE) --env=development up
+	$(GOOSE) --env=test up
+
+$(BENCHSTAT):
+	go get -u golang.org/x/perf/cmd/benchstat
+
+bench: | $(BENCHSTAT)
+	tmp=$$(mktemp); go list ./... | grep -v vendor | xargs go test -benchtime=2s -bench=. -run='^$$' > "$$tmp" 2>&1 && $(BENCHSTAT) "$$tmp"

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@
 SHELL = /bin/bash -x -o pipefail
 
 ifdef DATABASE_URL
-DATABASE_URL := $(DATABASE_URL)
-TEST_DATABASE_URL := $(DATABASE_URL)
+	DATABASE_URL := $(DATABASE_URL)
+	TEST_DATABASE_URL := $(DATABASE_URL)
 else
-DATABASE_URL := 'postgres://rickover@localhost:5432/rickover?sslmode=disable&timezone=UTC'
-TEST_DATABASE_URL := 'postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC'
+	DATABASE_URL := 'postgres://rickover@localhost:5432/rickover?sslmode=disable&timezone=UTC'
+	TEST_DATABASE_URL := 'postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC'
 endif
 
-BENCHSTAT := "$(GOPATH)/bin/benchstat"
-BUMP_VERSION := "$(GOPATH)/bin/bump_version"
-GODOCDOC := "$(GOPATH)/bin/godocdoc"
-GOOSE := "$(GOPATH)/bin/goose"
+BENCHSTAT := $(GOPATH)/bin/benchstat
+BUMP_VERSION := $(GOPATH)/bin/bump_version
+GODOCDOC := $(GOPATH)/bin/godocdoc
+GOOSE := $(GOPATH)/bin/goose
 
 test-install:
 	-createuser rickover --superuser --createrole --createdb --inherit
@@ -30,11 +30,10 @@ install:
 	go install ./...
 
 $(GODOCDOC):
-	echo "$(GOPATH)"
 	go get -u github.com/kevinburke/godocdoc
 
 docs: | $(GODOCDOC)
-	"$(GODOCDOC)"
+	$(GODOCDOC)
 
 testonly:
 	@DATABASE_URL=$(TEST_DATABASE_URL) go test -p 1 ./... -timeout 2s


### PR DESCRIPTION
Instead of depending on users to have the right binaries installed,
check whether we have them installed before running the necessary
commands, and install them if the user does not have them.