### PR TITLE
Stabilize tests part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: go
 go_import_path: github.com/Shyp/rickover
 
 go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - master
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ testonly:
 	@DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -timeout 10s
 
 race-testonly:
-	@DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -race -timeout 10s
+	DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -v -race -timeout 10s
 
 truncate-test: $(TRUNCATE_TABLES)
 	@DATABASE_URL=$(TEST_DATABASE_URL) $(TRUNCATE_TABLES)

--- a/server/authorizer.go
+++ b/server/authorizer.go
@@ -31,7 +31,7 @@ type Authorizer interface {
 // authenticate incoming requests.
 type SharedSecretAuthorizer struct {
 	allowedUsers map[string]string
-	mu           sync.Mutex
+	mu           sync.RWMutex
 }
 
 // NewSharedSecretAuthorizer creates a SharedSecretAuthorizer ready for use.
@@ -51,7 +51,9 @@ func (ssa *SharedSecretAuthorizer) AddUser(userId string, password string) {
 // Authorize returns nil if the userId and token have been added to c, and
 // a rest.Error if they are not allowed to access the API.
 func (c *SharedSecretAuthorizer) Authorize(userId string, token string) *rest.Error {
+	c.mu.RLock()
 	serverPass, ok := c.allowedUsers[userId]
+	c.mu.RUnlock()
 	if !ok {
 		if userId == "" {
 			return &rest.Error{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,7 +16,7 @@ import (
 func Test404JSONUnknownResource(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/foo/unknown", nil)
+	req := httptest.NewRequest("GET", "/foo/unknown", nil)
 	DefaultServer.ServeHTTP(w, req)
 	test.AssertEquals(t, w.Code, http.StatusNotFound)
 	var e rest.Error
@@ -38,13 +38,14 @@ var prototests = []struct {
 
 func TestXForwardedProtoDisallowed(t *testing.T) {
 	t.Parallel()
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("hello world"))
 	})
-	h := forbidNonTLSTrafficHandler(http.DefaultServeMux)
+	h := forbidNonTLSTrafficHandler(mux)
 	for _, tt := range prototests {
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest("GET", "/", nil)
 		req.Header.Set("X-Forwarded-Proto", tt.hval)
 		h.ServeHTTP(w, req)
 		if tt.allowed {
@@ -61,7 +62,7 @@ func TestXForwardedProtoDisallowed(t *testing.T) {
 
 func TestHomepageRendersVersion(t *testing.T) {
 	t.Parallel()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	req.SetBasicAuth("foo", "bar")
 	u := &UnsafeBypassAuthorizer{}
@@ -74,7 +75,7 @@ func TestHomepageRendersVersion(t *testing.T) {
 
 func TestHomepageForbidsUnknownUsers(t *testing.T) {
 	t.Parallel()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	req.SetBasicAuth("Unknown user", "Wrong password")
 	DefaultServer.ServeHTTP(w, req)
@@ -83,7 +84,7 @@ func TestHomepageForbidsUnknownUsers(t *testing.T) {
 
 func TestHomepageDisallowsUnauthedUsers(t *testing.T) {
 	t.Parallel()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	DefaultServer.ServeHTTP(w, req)
 	test.AssertEquals(t, w.Code, 401)
@@ -91,7 +92,7 @@ func TestHomepageDisallowsUnauthedUsers(t *testing.T) {
 
 func TestServerVersionHeader(t *testing.T) {
 	t.Parallel()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	req.SetBasicAuth("foo", "bar")
 	u := &UnsafeBypassAuthorizer{}
@@ -101,7 +102,7 @@ func TestServerVersionHeader(t *testing.T) {
 
 func TestStrictTransportHeader(t *testing.T) {
 	t.Parallel()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	req.SetBasicAuth("foo", "bar")
 	u := &UnsafeBypassAuthorizer{}

--- a/test/jobs/jobs_test.go
+++ b/test/jobs/jobs_test.go
@@ -50,7 +50,7 @@ func TestCreateReturnsRecord(t *testing.T) {
 	test.AssertEquals(t, j.Attempts, uint8(3))
 	test.AssertEquals(t, j.Concurrency, uint8(1))
 	diff := time.Since(j.CreatedAt)
-	test.Assert(t, diff < 20*time.Millisecond, fmt.Sprintf("too much time: %v", diff))
+	test.Assert(t, diff < 100*time.Millisecond, fmt.Sprintf("CreatedAt should be close to the current time, got %v", diff))
 }
 
 func TestGet(t *testing.T) {

--- a/test/services/process_job_test.go
+++ b/test/services/process_job_test.go
@@ -180,7 +180,7 @@ func TestWorkerDoesNotWaitConnectionFailure(t *testing.T) {
 	// Job processor client -> worker client -> generic rest client
 	jp.Client.Client.Client.Timeout = 20 * time.Millisecond
 
-	qj := factory.CreateAtMostOnceJob(t, factory.EmptyData)
+	_, qj := factory.CreateAtMostOnceJob(t, factory.EmptyData)
 	err := jp.DoWork(qj)
 	test.AssertNotError(t, err, "")
 	aj, err := archived_jobs.Get(qj.ID)

--- a/test/services/status_callback_test.go
+++ b/test/services/status_callback_test.go
@@ -40,7 +40,7 @@ func TestStatusCallbackFailedInsertsArchivedRecord(t *testing.T) {
 
 func TestStatusCallbackFailedAtMostOnceInsertsArchivedRecord(t *testing.T) {
 	defer test.TearDown(t)
-	qj := factory.CreateAtMostOnceJob(t, factory.EmptyData)
+	_, qj := factory.CreateAtMostOnceJob(t, factory.EmptyData)
 	err := services.HandleStatusCallback(qj.ID, "at-most-once", models.StatusFailed, 7, true)
 	test.AssertNotError(t, err, "")
 	_, err = queued_jobs.Get(qj.ID)

--- a/test/test.go
+++ b/test/test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func SetUp(t testing.TB) {
+	t.Helper()
 	if os.Getenv("DATABASE_URL") == "" {
 		os.Setenv("DATABASE_URL", "postgres://rickover@localhost:5432/rickover_test?sslmode=disable&timezone=UTC")
 	}
@@ -34,6 +35,7 @@ func TruncateTables() error {
 // TearDown deletes all records from the database, and marks the test as failed
 // if this was unsuccessful.
 func TearDown(t testing.TB) {
+	t.Helper()
 	if db.Connected() {
 		if err := TruncateTables(); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Avoid using DefaultServeMux, which panics when you register two
handlers for the same route (in the case for example that we run the
same test twice in a row in the same process).

- Use httptest.NewRequest, which panics if you get an error, and elide
the _ error handling.

- Fix data race in the SharedSecretAuthorizer (we were not guarding
a map access with a lock) by using a read/write lock.

- Bump test timeouts to account for test parallelization and
a potentially slow database.

- Modify tests that hit the database so they can run concurrently
without interfering with each other. Ensure that we are properly
cleaning up after tests that run in parallel.