### PR TITLE
Fix more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ docs: | $(GODOCDOC)
 	$(GODOCDOC)
 
 testonly:
-	@DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -timeout 10s
+	@DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -p=1 -timeout 10s
 
 race-testonly:
-	DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -v -race -timeout 10s
+	DATABASE_URL=$(TEST_DATABASE_URL) go list ./... | grep -v vendor | xargs go test -p=1 -race -timeout 10s
 
 truncate-test: $(TRUNCATE_TABLES)
 	@DATABASE_URL=$(TEST_DATABASE_URL) $(TRUNCATE_TABLES)
@@ -75,4 +75,4 @@ $(BENCHSTAT):
 	go get -u golang.org/x/perf/cmd/benchstat
 
 bench: | $(BENCHSTAT)
-	tmp=$$(mktemp); go list ./... | grep -v vendor | xargs go test -benchtime=2s -bench=. -run='^$$' > "$$tmp" 2>&1 && $(BENCHSTAT) "$$tmp"
+	tmp=$$(mktemp); go list ./... | grep -v vendor | xargs go test -p=1 -benchtime=2s -bench=. -run='^$$' > "$$tmp" 2>&1 && $(BENCHSTAT) "$$tmp"

--- a/README.md
+++ b/README.md
@@ -499,6 +499,15 @@ boom -n 30000 -c 100 -d '{"data": {"user-agent": "boom"}}' -m PUT http://localho
 
 [boom]: https://github.com/rakyll/boom
 
+## Testing
+
+Tests hit the database, and should either be able to run in parallel with other
+tests or clean up after themselves.
+
+Note you must run tests with `-p=1`, so packages are tested in turn. Otherwise
+`t.Parallel()` will run parallel tests from different suites at the same time as
+each other, which we currently don't support.
+
 ## Supported versions
 
 The database uses `jsonb`, which is only available in Postgres 9.4 and beyond.

--- a/test/archived_jobs/archived_jobs_test.go
+++ b/test/archived_jobs/archived_jobs_test.go
@@ -23,11 +23,12 @@ var sampleJob = models.Job{
 func TestAll(t *testing.T) {
 	test.SetUp(t)
 	defer test.TearDown(t)
-	// Put parallel tests here.
-	t.Run("testCreateJobReturnsJob", testCreateJobReturnsJob)
-	t.Run("TestCreateArchivedJobWithNoQueuedReturnsErrNoRows", testCreateArchivedJobWithNoQueuedReturnsErrNoRows)
-	t.Run("TestArchivedJobFailsIfJobExists", testArchivedJobFailsIfJobExists)
-	t.Run("TestCreateJobStoresJob", testCreateJobStoresJob)
+	t.Run("Parallel", func(t *testing.T) {
+		t.Run("testCreateJobReturnsJob", testCreateJobReturnsJob)
+		t.Run("TestCreateArchivedJobWithNoQueuedReturnsErrNoRows", testCreateArchivedJobWithNoQueuedReturnsErrNoRows)
+		t.Run("TestArchivedJobFailsIfJobExists", testArchivedJobFailsIfJobExists)
+		t.Run("TestCreateJobStoresJob", testCreateJobStoresJob)
+	})
 }
 
 // Test that creating an archived job returns the job

--- a/test/factory/factory.go
+++ b/test/factory/factory.go
@@ -3,6 +3,7 @@ package factory
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -164,7 +165,7 @@ func createJobAndQueuedJob(t testing.TB, j models.Job, data json.RawMessage, ran
 		id = JobId
 	}
 	qj, err := queued_jobs.Enqueue(id, j.Name, runAfter, expiresAt, data)
-	test.AssertNotError(t, err, "")
+	test.AssertNotError(t, err, fmt.Sprintf("Error creating queued job %s (job name %s)", id, j.Name))
 	return job, qj
 }
 

--- a/test/jobs/jobs_test.go
+++ b/test/jobs/jobs_test.go
@@ -5,14 +5,25 @@ import (
 	"testing"
 	"time"
 
+	types "github.com/Shyp/go-types"
 	"github.com/Shyp/rickover/models"
 	"github.com/Shyp/rickover/models/jobs"
 	"github.com/Shyp/rickover/test"
 )
 
-func TestCreateMissingFields(t *testing.T) {
-	t.Parallel()
+func TestAll(t *testing.T) {
 	test.SetUp(t)
+	defer test.TearDown(t)
+	t.Run("Parallel", func(t *testing.T) {
+		t.Run("CreateMissingFields", testCreateMissingFields)
+		t.Run("CreateInvalidFields", testCreateInvalidFields)
+		t.Run("CreateReturnsRecord", testCreateReturnsRecord)
+		t.Run("Get", testGet)
+	})
+}
+
+func testCreateMissingFields(t *testing.T) {
+	t.Parallel()
 	job := models.Job{
 		Name: "email-signup",
 	}
@@ -21,7 +32,7 @@ func TestCreateMissingFields(t *testing.T) {
 	test.AssertEquals(t, err.Error(), "Invalid delivery_strategy: \"\"")
 }
 
-func TestCreateInvalidFields(t *testing.T) {
+func testCreateInvalidFields(t *testing.T) {
 	t.Parallel()
 	test.SetUp(t)
 	job := models.Job{
@@ -40,12 +51,23 @@ var sampleJob = models.Job{
 	Concurrency:      1,
 }
 
-func TestCreateReturnsRecord(t *testing.T) {
-	test.SetUp(t)
-	defer test.TearDown(t)
-	j, err := jobs.Create(sampleJob)
+func newJob(t *testing.T) models.Job {
+	t.Helper()
+	id, _ := types.GenerateUUID("jobname_")
+	return models.Job{
+		Name:             id.String(),
+		DeliveryStrategy: models.StrategyAtLeastOnce,
+		Attempts:         3,
+		Concurrency:      1,
+	}
+}
+
+func testCreateReturnsRecord(t *testing.T) {
+	t.Parallel()
+	j0 := newJob(t)
+	j, err := jobs.Create(j0)
 	test.AssertNotError(t, err, "")
-	test.AssertEquals(t, j.Name, "email-signup")
+	test.AssertEquals(t, j.Name, j0.Name)
 	test.AssertEquals(t, j.DeliveryStrategy, models.StrategyAtLeastOnce)
 	test.AssertEquals(t, j.Attempts, uint8(3))
 	test.AssertEquals(t, j.Concurrency, uint8(1))
@@ -53,16 +75,16 @@ func TestCreateReturnsRecord(t *testing.T) {
 	test.Assert(t, diff < 100*time.Millisecond, fmt.Sprintf("CreatedAt should be close to the current time, got %v", diff))
 }
 
-func TestGet(t *testing.T) {
-	test.SetUp(t)
-	defer test.TearDown(t)
-	_, err := jobs.Create(sampleJob)
+func testGet(t *testing.T) {
+	t.Parallel()
+	j0 := newJob(t)
+	_, err := jobs.Create(j0)
 	test.AssertNotError(t, err, "")
-	j, err := jobs.Get("email-signup")
-	test.AssertEquals(t, j.Name, "email-signup")
+	j, err := jobs.Get(j0.Name)
+	test.AssertEquals(t, j.Name, j0.Name)
 	test.AssertEquals(t, j.DeliveryStrategy, models.StrategyAtLeastOnce)
 	test.AssertEquals(t, j.Attempts, uint8(3))
 	test.AssertEquals(t, j.Concurrency, uint8(1))
 	diff := time.Since(j.CreatedAt)
-	test.Assert(t, diff < 20*time.Millisecond, "")
+	test.Assert(t, diff < 100*time.Millisecond, "")
 }

--- a/test/rickover-truncate-tables/main.go
+++ b/test/rickover-truncate-tables/main.go
@@ -12,7 +12,7 @@ func main() {
 	if err := setup.DB(db.DefaultConnection, 1); err != nil {
 		log.Fatal(err)
 	}
-	if err := test.TruncateTables(); err != nil {
+	if err := test.TruncateTables(nil); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/test/services/process_job_test.go
+++ b/test/services/process_job_test.go
@@ -21,9 +21,19 @@ import (
 	"github.com/nu7hatch/gouuid"
 )
 
-func TestExpiredJobNotEnqueued(t *testing.T) {
-	t.Parallel()
+func TestAll(t *testing.T) {
 	test.SetUp(t)
+	defer test.TearDown(t)
+	t.Run("Parallel", func(t *testing.T) {
+		t.Run("ExpiredJobNotEnqueued", testExpiredJobNotEnqueued)
+		t.Run("StatusCallbackFailedNotRetryableArchivesRecord", testStatusCallbackFailedNotRetryableArchivesRecord)
+		t.Run("StatusCallbackFailedAtLeastOnceUpdatesQueuedRecord", testStatusCallbackFailedAtLeastOnceUpdatesQueuedRecord)
+		t.Run("TestStatusCallbackFailedInsertsArchivedRecord", testStatusCallbackFailedInsertsArchivedRecord)
+	})
+}
+
+func testExpiredJobNotEnqueued(t *testing.T) {
+	t.Parallel()
 
 	c1 := make(chan bool, 1)
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +58,7 @@ func TestExpiredJobNotEnqueued(t *testing.T) {
 		case <-c1:
 			t.Fatalf("worker made a request to the server")
 			return
-		case <-time.After(40 * time.Millisecond):
+		case <-time.After(60 * time.Millisecond):
 			return
 		}
 	}

--- a/test/services/status_callback_test.go
+++ b/test/services/status_callback_test.go
@@ -26,10 +26,10 @@ func TestStatusCallbackInsertsArchivedRecordDeletesQueuedRecord(t *testing.T) {
 	test.AssertEquals(t, aj.Status, models.StatusSucceeded)
 }
 
-func TestStatusCallbackFailedInsertsArchivedRecord(t *testing.T) {
-	defer test.TearDown(t)
-	qj := factory.CreateQueuedJob(t, factory.EmptyData)
-	err := services.HandleStatusCallback(qj.ID, "echo", models.StatusFailed, 1, true)
+func testStatusCallbackFailedInsertsArchivedRecord(t *testing.T) {
+	t.Parallel()
+	job, qj := factory.CreateUniqueQueuedJob(t, factory.EmptyData)
+	err := services.HandleStatusCallback(qj.ID, job.Name, models.StatusFailed, 1, true)
 	test.AssertNotError(t, err, "")
 	_, err = queued_jobs.Get(qj.ID)
 	test.AssertEquals(t, err, queued_jobs.ErrNotFound)
@@ -50,10 +50,10 @@ func TestStatusCallbackFailedAtMostOnceInsertsArchivedRecord(t *testing.T) {
 	test.AssertEquals(t, aj.ID.String(), qj.ID.String())
 }
 
-func TestStatusCallbackFailedAtLeastOnceUpdatesQueuedRecord(t *testing.T) {
-	defer test.TearDown(t)
-	qj := factory.CreateQueuedJob(t, factory.EmptyData)
-	err := services.HandleStatusCallback(qj.ID, "echo", models.StatusFailed, 7, true)
+func testStatusCallbackFailedAtLeastOnceUpdatesQueuedRecord(t *testing.T) {
+	t.Parallel()
+	job, qj := factory.CreateUniqueQueuedJob(t, factory.EmptyData)
+	err := services.HandleStatusCallback(qj.ID, job.Name, models.StatusFailed, 7, true)
 	test.AssertNotError(t, err, "")
 
 	qj, err = queued_jobs.Get(qj.ID)
@@ -64,7 +64,7 @@ func TestStatusCallbackFailedAtLeastOnceUpdatesQueuedRecord(t *testing.T) {
 	test.AssertEquals(t, err, archived_jobs.ErrNotFound)
 }
 
-func TestStatusCallbackFailedNotRetryableArchivesRecord(t *testing.T) {
+func testStatusCallbackFailedNotRetryableArchivesRecord(t *testing.T) {
 	t.Parallel()
 	qj := factory.CreateQJ(t)
 	err := services.HandleStatusCallback(qj.ID, qj.Name, models.StatusFailed, qj.Attempts, false)

--- a/test/test.go
+++ b/test/test.go
@@ -20,11 +20,18 @@ func SetUp(t testing.TB) {
 }
 
 // TruncateTables deletes all records from the database.
-func TruncateTables() error {
+func TruncateTables(t testing.TB) error {
 	getTableDelete := func(table string) string {
-		return fmt.Sprintf("DELETE FROM %[1]s", table)
+		return "DELETE FROM " + table
 	}
-	_, err := db.Conn.Exec(fmt.Sprintf("BEGIN; %s;\n%s;\n%s; COMMIT",
+	var name string
+	if t == nil {
+		name = "TruncateTables"
+	} else {
+		name = t.Name()
+	}
+	_, err := db.Conn.Exec(fmt.Sprintf("-- %s\n%s;\n%s;\n%s",
+		name,
 		getTableDelete("archived_jobs"),
 		getTableDelete("queued_jobs"),
 		getTableDelete("jobs"),
@@ -37,7 +44,7 @@ func TruncateTables() error {
 func TearDown(t testing.TB) {
 	t.Helper()
 	if db.Connected() {
-		if err := TruncateTables(); err != nil {
+		if err := TruncateTables(t); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Run tests in parallel where they can be correctly parallelized, with
one TearDown call surrounding the entire block of subtests.

Parallelize more tests. Note in the README that while tests within
a package can be parallelized, test packages cannot be parallelized.